### PR TITLE
Give partial select to all parents.

### DIFF
--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -86,7 +86,7 @@ export class AppComponent {
         //update parent if needed (recursive)
         let updateParent = (node: any) => {
             if (node.parentNodeId != 0) {
-                const parentNode = this.hash[node.parentNodeId];
+                let parentNode = this.hash[node.parentNodeId];
                 const siblings = parentNode.children;
                 parentNode.partialSelection = false;
                 let equalSiblings = true;

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -101,7 +101,10 @@ export class AppComponent {
                         updateParent(parentNode);
                     }
                 }else{
-                    parentNode.partialSelection = true;
+                    while (parentNode) {
+                        parentNode.partialSelection = true;
+                        parentNode = parentNode.parent;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This makes the UI more clear, as the checkbox on the parent indicates that all children are selected.